### PR TITLE
fix: stricter JSON format for dimension selector responses

### DIFF
--- a/src/navigation/dimension_selector.rs
+++ b/src/navigation/dimension_selector.rs
@@ -99,8 +99,12 @@ Reasoning: Analytical thinking (L02), technical problem-solving (L07), meta-awar
 # USER QUERY
 {query}
 
-# YOUR RESPONSE
-Return ONLY a JSON array of layer numbers (1-14):
+# YOUR RESPONSE FORMAT
+You MUST respond with ONLY a valid JSON array. No explanations, no text, just the array.
+
+Example: [1, 2, 7]
+
+Your response:
 "#;
 
 impl DimensionSelector {


### PR DESCRIPTION
## Problem
Claude Haiku sometimes returns explanatory text along with the JSON array, causing parse failures and 500 errors.

Example bad response:
```
Here are the relevant layers: [1, 2, 7]
```

## Solution
- Make prompt extremely explicit: 'ONLY a valid JSON array'
- Add example format
- Clear instruction: 'No explanations, no text, just the array'

## Impact
- Reduces 500 errors from dimension selector
- More reliable LLM response parsing
- Works with existing fallback mechanism (#82bd76c)

## Testing
Will test on production after merge to verify format compliance.